### PR TITLE
Update departments.ps1

### DIFF
--- a/departments.ps1
+++ b/departments.ps1
@@ -23,21 +23,12 @@ function Get-AFASConnectorData {
         $take = 100
         $skip = 0
 
-        $uri = $BaseUri + "/connectors/" + $Connector + "?skip=$skip&take=$take"
-        $dataset = Invoke-RestMethod -Method Get -Uri $uri -Headers $Headers -UseBasicParsing
-
-        foreach ($record in $dataset.rows) { [void]$data.Value.add($record) }
-
-        $skip += $take
-        while (@($dataset.rows).count -eq $take) {
+        do  {
             $uri = $BaseUri + "/connectors/" + $Connector + "?skip=$skip&take=$take"
-
             $dataset = Invoke-RestMethod -Method Get -Uri $uri -Headers $Headers -UseBasicParsing
-
             $skip += $take
-
             foreach ($record in $dataset.rows) { [void]$data.Value.add($record) }
-        }
+        }while (@($dataset.rows).count -eq $take)
     }
     catch {
         $data.Value = $null


### PR DESCRIPTION
In stead of calling a piece of script before a while loop, and then repeating the same script in the while loop, you can use a do while loop.
This way you prevent redundancy and needing to change a script in 2 places but the effect is the same.

We checked if this works (Geo and me). Please review if this is best practice.